### PR TITLE
fix: properly pass the error obj to eliza-logger

### DIFF
--- a/src/actions/retrieve.ts
+++ b/src/actions/retrieve.ts
@@ -72,7 +72,7 @@ export const retrieveAction: Action = {
             elizaLogger.log("File(s) retrieved successfully!");
             return true;
         } catch (error) {
-            elizaLogger.error("Error during retrieve file(s) from storage:", error);
+            elizaLogger.error(error, "Error during retrieve file(s) from storage");
             await callback?.({ text: `Error during retrieve file(s) from storage: ${error.message}` });
             return false;
         }

--- a/src/actions/upload.ts
+++ b/src/actions/upload.ts
@@ -81,7 +81,7 @@ export const uploadAction: Action = {
             elizaLogger.success("File(s) uploaded to Storacha");
             return true;
         } catch (error) {
-            elizaLogger.error("Error uploading file(s) to Storacha", error);
+            elizaLogger.error(error, "Error uploading file(s) to Storacha");
             await callback?.({
                 text: "I'm sorry, I couldn't upload the file(s) to Storacha. Please try again later.",
                 content: { error: error.message },

--- a/src/clients/storage.ts
+++ b/src/clients/storage.ts
@@ -24,7 +24,7 @@ export class StorageClientInstanceImpl implements ClientInstance {
             this.storage = await createStorageClient(this.config);
             elizaLogger.success(`✅ Storage client successfully started`);
         } catch (error) {
-            elizaLogger.error(`❌ Storage client failed to start: ${error}`);
+            elizaLogger.error(error, "❌ Storage client failed to start");
             throw error;
         }
     }

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -38,7 +38,7 @@ export async function validateStorageClientConfig(
         const c = storageClientEnvSchema.parse(config);
         return c;
     } catch (error) {
-        elizaLogger.error("Storage client config validation failed", error);
+        elizaLogger.error(error, "Storage client config validation failed");
         if (error instanceof z.ZodError) {
             const errorMessages = error.errors
                 .map((err) => `${err.path.join(".")}: ${err.message}`)


### PR DESCRIPTION
#### Context
When errors occur in production, the logs must contain the full stack trace information, making debugging much easier.

The previous implementation did not show the stack traces at all.

#### Changes

- Updated all the actions and clients to correctly log errors with the full error object.
- Added tests