### PR TITLE
fix: update readme to install plugin from official registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Storacha plugin enables agents to interact with a distributed storage networ
 ## Installation
 
 ```bash
-pnpm install @storacha/elizaos-plugin
+npx elizaos plugins add @elizaos-plugins/plugin-storacha
 ```
 
 ## Configuration
@@ -17,12 +17,11 @@ pnpm install @storacha/elizaos-plugin
 1. Add the plugin to the Agent configuration, e.g.
     ```typescript
     // eliza/agent/src/defaultCharacter.ts
-    import { storagePlugin } from "@storacha/elizaos-plugin";
 
     export const defaultCharacter: Character = {
         name: "Eliza",
         username: "eliza",
-        plugins: [storagePlugin],
+        plugins: ["@elizaos-plugins/plugin-storacha"],
         ...
     };
     ```
@@ -103,12 +102,30 @@ pnpm run build
 
 ## Dependencies
 
-- @elizaos/core: workspace:*
+- `@elizaos/core: workspace:*`
 
 ## Future Enhancements
 - Conversation History & Agent Context Backup
 - Cross Agent Data Sharing
 - Encryption with LIT Protocol
+
+## Storacha Client
+
+You can access the Storacha Client directly from the agent code if the plugin is enabled in the `character` file e.g.:
+
+**Upload**
+```js
+const storageClient = await getStorageClient(runtime);
+if (storageClient) {
+    const cid = await storageClient.getStorage().uploadFile(...);
+}
+```
+
+**Retrieve**
+```js
+const resp = await storageClient.getContent(cid)
+const content = await resp.arrayBuffer()
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -111,21 +111,7 @@ pnpm run build
 
 ## Storacha Client
 
-You can access the Storacha Client directly from the agent code if the plugin is enabled in the `character` file e.g.:
-
-**Upload**
-```js
-const storageClient = await getStorageClient(runtime);
-if (storageClient) {
-    const cid = await storageClient.getStorage().uploadFile(...);
-}
-```
-
-**Retrieve**
-```js
-const resp = await storageClient.getContent(cid)
-const content = await resp.arrayBuffer()
-```
+You can access the Storacha Client directly from the agent code if the plugin is enabled in the `character` file, see the [Quickstart for AI guide](https://docs.storacha.network/ai/quickstart/#elizaos) for more info.
 
 ## License
 


### PR DESCRIPTION
Now that we have the plugin added to the official registry we need to follow their process to enable it:

Command:
```sh
npx elizaos plugins add @elizaos-plugins/plugin-storacha
```

Output:
> using git version 2.49.0
cloning plugin-storacha to /home/dev/eliza/packages/plugin-storacha
Making sure plugin has access to @elizaos/core
Updating plugins package.json name to @elizaos-plugins/plugin-storacha
Adding plugin @elizaos-plugins/plugin-storacha to agent/package.json
@elizaos-plugins/plugin-storacha attempted installation is complete
Remember to add it to your character file's plugin field: ["@elizaos-plugins/plugin-storacha"]

Also added the docs to use the Storacha Client.